### PR TITLE
Add DAG Manager API skeleton

### DIFF
--- a/src/qmtl/dag_manager/__init__.py
+++ b/src/qmtl/dag_manager/__init__.py
@@ -1,0 +1,1 @@
+"""QMTL DAG Manager package."""

--- a/src/qmtl/dag_manager/api.py
+++ b/src/qmtl/dag_manager/api.py
@@ -1,0 +1,88 @@
+"""FastAPI skeleton for the DAG Manager service."""
+
+import logging
+from typing import List
+
+from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+
+from .services.metadata_service import MetadataService
+from .services.node_service import NodeService
+from .services.stream_service import StreamService
+from .services.dependency_service import DependencyService
+
+
+app = FastAPI(title="QMTL DAG Manager API", version="0.1.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_metadata_service() -> MetadataService:
+    node_service = NodeService()
+    stream_service = StreamService()
+    dependency_service = DependencyService()
+    return MetadataService(node_service, stream_service, dependency_service)
+
+
+# ----------------------- API Endpoints -----------------------
+
+
+@app.get("/v1/dag-manager/nodes")
+async def list_nodes(service: MetadataService = Depends(get_metadata_service)):
+    try:
+        return {"nodes": service.list_nodes()}
+    except NotImplementedError:
+        logger.debug("list_nodes not implemented")
+        raise HTTPException(status_code=501, detail="NotImplemented")
+
+
+@app.get("/v1/dag-manager/nodes/{node_id}/dependencies")
+async def list_node_dependencies(
+    node_id: str, service: MetadataService = Depends(get_metadata_service)
+):
+    try:
+        return {"dependencies": service.get_node_dependencies(node_id)}
+    except NotImplementedError:
+        logger.debug("get_node_dependencies not implemented")
+        raise HTTPException(status_code=501, detail="NotImplemented")
+
+
+@app.get("/v1/dag-manager/nodes/by-tags")
+async def list_nodes_by_tags(
+    tags: List[str] = Query(...), service: MetadataService = Depends(get_metadata_service)
+):
+    try:
+        return {"nodes": service.list_nodes_by_tags(tags)}
+    except NotImplementedError:
+        logger.debug("list_nodes_by_tags not implemented")
+        raise HTTPException(status_code=501, detail="NotImplemented")
+
+
+@app.get("/v1/dag-manager/streams")
+async def list_streams(service: MetadataService = Depends(get_metadata_service)):
+    try:
+        return {"streams": service.list_streams()}
+    except NotImplementedError:
+        logger.debug("list_streams not implemented")
+        raise HTTPException(status_code=501, detail="NotImplemented")
+
+
+@app.get("/v1/dag-manager/events")
+async def list_events():
+    raise HTTPException(status_code=501, detail="NotImplemented")
+
+
+@app.get("/v1/dag-manager/nodes/{node_id}/callbacks")
+async def list_callbacks(node_id: str, service: MetadataService = Depends(get_metadata_service)):
+    try:
+        return {"callbacks": service.list_callbacks(node_id)}
+    except NotImplementedError:
+        logger.debug("list_callbacks not implemented")
+        raise HTTPException(status_code=501, detail="NotImplemented")

--- a/src/qmtl/dag_manager/services/dependency_service.py
+++ b/src/qmtl/dag_manager/services/dependency_service.py
@@ -1,0 +1,11 @@
+"""Placeholder Dependency service for DAG Manager."""
+
+from typing import List
+
+
+class DependencyService:
+    """Service for node dependency operations."""
+
+    def get_dependencies(self, node_id: str) -> List[str]:
+        """Return upstream dependency node IDs for a node."""
+        raise NotImplementedError

--- a/src/qmtl/dag_manager/services/metadata_service.py
+++ b/src/qmtl/dag_manager/services/metadata_service.py
@@ -1,0 +1,36 @@
+"""Facade service wrapping individual DAG Manager services."""
+
+from typing import List
+
+from .node_service import NodeService
+from .stream_service import StreamService
+from .dependency_service import DependencyService
+
+
+class MetadataService:
+    """Facade entry point for DAG Manager domain operations."""
+
+    def __init__(
+        self,
+        node_service: NodeService,
+        stream_service: StreamService,
+        dependency_service: DependencyService,
+    ):
+        self.node_service = node_service
+        self.stream_service = stream_service
+        self.dependency_service = dependency_service
+
+    def list_nodes(self) -> List[dict]:
+        return self.node_service.list_nodes()
+
+    def get_node_dependencies(self, node_id: str) -> List[str]:
+        return self.dependency_service.get_dependencies(node_id)
+
+    def list_nodes_by_tags(self, tags: List[str]) -> List[dict]:
+        return self.node_service.list_by_tags(tags)
+
+    def list_streams(self) -> List[dict]:
+        return self.stream_service.list_streams()
+
+    def list_callbacks(self, node_id: str) -> List[dict]:
+        return self.node_service.list_callbacks(node_id)

--- a/src/qmtl/dag_manager/services/node_service.py
+++ b/src/qmtl/dag_manager/services/node_service.py
@@ -1,0 +1,19 @@
+"""Placeholder Node service for DAG Manager."""
+
+from typing import List
+
+
+class NodeService:
+    """Service for node metadata operations."""
+
+    def list_nodes(self) -> List[dict]:
+        """Return list of nodes."""
+        raise NotImplementedError
+
+    def list_by_tags(self, tags: List[str]) -> List[dict]:
+        """Return nodes filtered by tags."""
+        raise NotImplementedError
+
+    def list_callbacks(self, node_id: str) -> List[dict]:
+        """Return callbacks associated with a node."""
+        raise NotImplementedError

--- a/src/qmtl/dag_manager/services/stream_service.py
+++ b/src/qmtl/dag_manager/services/stream_service.py
@@ -1,0 +1,11 @@
+"""Placeholder Stream service for DAG Manager."""
+
+from typing import List
+
+
+class StreamService:
+    """Service for stream topic operations."""
+
+    def list_streams(self) -> List[dict]:
+        """Return list of streams."""
+        raise NotImplementedError

--- a/tests/unit/dag_manager/test_api.py
+++ b/tests/unit/dag_manager/test_api.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+
+from qmtl.dag_manager.api import app
+
+client = TestClient(app)
+
+
+def test_list_nodes_not_implemented():
+    resp = client.get("/v1/dag-manager/nodes")
+    assert resp.status_code == 501
+    assert resp.json()["detail"] == "NotImplemented"
+
+
+def test_list_node_dependencies_not_implemented():
+    resp = client.get("/v1/dag-manager/nodes/n1/dependencies")
+    assert resp.status_code == 501
+    assert resp.json()["detail"] == "NotImplemented"
+
+
+def test_list_nodes_by_tags_not_implemented():
+    resp = client.get("/v1/dag-manager/nodes/by-tags", params={"tags": ["a"]})
+    assert resp.status_code == 501
+    assert resp.json()["detail"] == "NotImplemented"
+
+
+def test_list_streams_not_implemented():
+    resp = client.get("/v1/dag-manager/streams")
+    assert resp.status_code == 501
+    assert resp.json()["detail"] == "NotImplemented"
+
+
+def test_list_events_not_implemented():
+    resp = client.get("/v1/dag-manager/events")
+    assert resp.status_code == 501
+    assert resp.json()["detail"] == "NotImplemented"
+
+
+def test_list_callbacks_not_implemented():
+    resp = client.get("/v1/dag-manager/nodes/n1/callbacks")
+    assert resp.status_code == 501
+    assert resp.json()["detail"] == "NotImplemented"


### PR DESCRIPTION
## Summary
- add DAG Manager package with placeholder services
- create FastAPI API skeleton implementing DAG Manager routes
- add unit tests verifying routes return `NotImplemented`

## Testing
- `make test` *(fails: No module named pytest)*